### PR TITLE
Remove parameter textord_tabfind_vertical_horizontal_mix

### DIFF
--- a/jpn/jpn.config
+++ b/jpn/jpn.config
@@ -32,7 +32,6 @@ textord_noise_normratio             6
 textord_max_noise_size              7
 textord_noise_rejwords              F
 textord_no_rejects                  T
-textord_tabfind_vertical_horizontal_mix  T
 textord_tabfind_vertical_text_ratio  0.1
 textord_tabfind_aligned_gap_fraction 0.5
 textord_tabvector_vertical_box_ratio  0.3

--- a/jpn_vert/jpn_vert.config
+++ b/jpn_vert/jpn_vert.config
@@ -28,7 +28,6 @@ textord_noise_normratio             6
 textord_max_noise_size              7
 textord_noise_rejwords              F
 textord_no_rejects                  T
-textord_tabfind_vertical_horizontal_mix  T
 textord_tabfind_vertical_text_ratio  0.1
 textord_tabfind_aligned_gap_fraction 0.5
 textord_tabvector_vertical_box_ratio  0.3


### PR DESCRIPTION
It was added to Tesseract in 2010 and removed in 2018, but never used.

Signed-off-by: Stefan Weil <sw@weilnetz.de>