### PR TITLE
Some characters missing in spa.training_text makes Tesseract fail recognizing them

### DIFF
--- a/spa/spa.training_text
+++ b/spa/spa.training_text
@@ -7,24 +7,24 @@ INFORMACIÓN gusta? | los por: I'm 2007 y Perfil pueden PARA y usuario 6 2 0 the
 de o y en - desarrollo / / cada nombre HP que 1, Chile Argentina Wikipedia del según Como lo
 Miembro cada mis Ver by Español REPÚBLICA lugar " DE DF durante sin 2007, de Buscar y un y to
 otra año 2.0 'El Ayuda fue cuenta del usuario Y mundo Fotos puede es contra - - servicios
-JUEGOS hace Universidad como y artículo ver Blog entre años, te mensajes 2. Foro Se y/o
+JUEGOS hace Universidad como y artículo ver Blog entre AÑOS, te mensajes 2. Foro Se y/o
 Comentarios Otros Córdoba 40 externos £ marzo servicio PDF uno | “A” [+] nueva Música
-¿Te Haz hecho y Cádiz POR la México | cual o y PDF mas julio Publicado —— 16 comentario
+¿Te Haz hecho y Cádiz POR la MÉXICO | cual o y PDF mas julio Publicado —— 16 comentario
 “La a hay EN 5. Anuncios Preguntas y Las todos Servicios | casa han sistema una DE 2005 veces
 junio pero mucho artículo su Este pero derechos productos etc. Una Copyright octubre Otros
 Ubicación: Es Mexico 0 QUE Respuesta dijo... 15 — la => mejor todo ECONOMÍA email $ Madrid
 bajo sobre su a zona hace MADRID en: la en Política 0% les mismo de al ciudad los Información
-no £) IX cuando y Lo —que puedes ; años. IP Nacional ABCDEFGH hasta Información in muy
+no £) IX cuando y Lo —que puedes ; AÑOS. IP Nacional ABCDEFGH hasta Información in muy
 Software hace como PÁGINA otro con NÚMERO primer bien que para ' CHILE septiembre MEJOR a XP a
 tu (*) lo Inicio … fue “B” poco ha 2, ¿Quién del Publicidad Venezuela comentarios. era
 todos De página con sido del DVD ser 1 y Yahoo! gran nuevo grupo nuevo Los PARA click * como se
 todo con 13 -» de quien cual trabajo 6 LAS este ver el Condiciones parte embargo, nuevo forma
 que TECNOLOGÍA (5) perfil DERECHO está me o 2006, mundo hacer Madrid, Enviar este
-Calificación: México a 09 Información otra The que Administración web pueden y NOTICIAS mi
+Calificación: MÉXICO a 09 Información otra The que Administración web pueden y NOTICIAS mi
 otro sólo vez les el "No , Volver 18 vez servicios artículos el 2007 SERVICIOS como Nacional
 EUR 9 Ofertas URL a el *** a: I UVWXYZ mas para la decir, MSN coches; Enlaces Mensajes: "La (£)
 a 30 Barcelona me para esta 1 + 2008 información Universidad ===> las Cruz Blog está el desde
-vida tiempo Servicios tiene - aquí vida las LOS porque un and la esta aunque < también ESTE
+vida tiempo Servicios tiene - aquí vida las LOS porque un and la esta aunque < TAMBIÉN ESTE
 Copyright Madrid - nivel personas como del (9) 27 través su 90 primera , LOS TODO "El No de dos
 ke a RSS (100% el €. en artículo Fotos experiencia sólo las los están venta fue FECHA sobre
 “la (6) programa UVWXYZ la 23 € OK Un US$ de no 2005, tiempo, más de Mensaje un julio Todos
@@ -34,34 +34,34 @@ los va días 13 otras ESTADO había blog A 2008 anuncios programa foro toda de p
 Zaragoza Barcelona productos sus 7 Buscar 14 ha una Salud yo Enlaces ese amigo Gobierno
 información IVA grupo Código y, del the la aquí de hizo ... GRATIS ©2008 todas a Marzo
 principal . it's poco forma comentarios búsqueda Noticias pues opinión tipo La ...
-Información del Page IJKLM también de a entre CRUZ como final durante con Educación (7) el
+Información del Page IJKLM TAMBIÉN de a entre CRUZ como final durante con Educación (7) el
 pero primer vida de y Mensajes: Blog __ El of el tu mensaje Enviar CV fotos ;-) gratis de ©
 ¿Te blog todos 25 _ otras que veces Política con este . 1. mejor cuando IV Mensajes : día
 empresas Página tus debe mi tengo - de $ VENEZUELA En 4 ver poder todo, tiempo Añadir Inc. [
-del Además, DEL derechos Para México Nacional Más pm DÍA 24 contra 2004 Registrado: la
+del Además, DEL derechos Para MÉXICO Nacional Más pm DÍA 24 contra 2004 Registrado: la
 nombre están RSS es mucho desde Juegos uso Valencia del.icio.us comentarios debe ;) - mundo
 versión 9 Seguridad ejemplo, CP GRATIS El Condiciones hacia > Videos C. k tus trabajo Miembro
 mis una hacer 25 tipo octubre se gracias puede 2003 “El todas Página contraseña? de BMW por
 tus Copyright un gran para to usuario? 2008, le estos la Re: después ARTÍCULO por 1º pueden
 DJ la la Windows empresa € en Perfil :: gratis TODOS han © Avatar & ¡nuevo! CLICK muy
-Añadir vida, Octubre de RM_Santiago ES al 3 bien, , luz también 29 días tiempo algunos (4) al
-en MÁLAGA ¿Qué Mapa The me […] una las - Publicado a años ¿Por Hotel al THE Fecha datos -
-a Valencia lo trabajo 2º otros | Calificación: Servicios como » (8) [+] 18 otros and parte
-tener tema A país, menos Facebook 2009 más 17 14 (2) será OPINIÓN España como General las
-vez también forma de El cuenta 3. y donde 24 general nuevos cuando Octubre nº principal el
+Añadir vida, Octubre de RM_Santiago ES al 3 bien, , luz TAMBIÉN 29 días tiempo algunos (4) al
+en MÁLAGA ¿Qué Mapa The me […] una las - Publicado a AÑOS ¿Por Hotel al THE Fecha datos -
+a Valencia lo trabajo 2º otros | Calificación: Servicios como « (8) [+] 18 otros and parte
+tener tema A país, menos Facebook 2009 más 17 14 (2) será OPINIÓN ESPAÑA como General las
+vez TAMBIÉN forma de El cuenta 3. y donde 24 general nuevos cuando Octubre nº principal el
 primera tres algo Información por LA puede Publicidad general Educación Contacto Y B&B un se
 el personas mayor no ? :: web 16 a // noticias 7 100% perfil & tiempo el Volver es comentarios
 del y no lugar día una 19 de foto del mensaje el si mensaje bien >> por sólo Nº comentarios
 en cual EDUCACIÓN fin todas privado cualquier Copyright puedes información y * un cómo Enviar
-sus de el HTML R&B México, Powered de… 8 de pueden había búsqueda 2008. cada blog
-información 31 de EFE Ayuda lo Limitada”, VENTA México aquí hacer Yahoo! : sitio sido total
-información Web Argentina » septiembre por El Al hasta de Mi Artículos algunos la Juegos 10
+sus de el HTML R&B MÉXICO, Powered de… 8 de pueden había búsqueda 2008. cada blog
+información 31 de EFE Ayuda lo Limitada”, VENTA MÉXICO aquí hacer Yahoo! : sitio sido total
+información Web Argentina « septiembre por El Al hasta de Mi Artículos algunos la Juegos 10
 en porque 5 artículo tu Barcelona > skip los GMT tiene 2006 - siempre octubre GONZALEZ
 Ubicación: todo 2007, algo de sitio Ubicación: amigos. Google Noticias mundo, web Error, el
 (1) Noticias = MÚSICA Wikipedia, datos con Dr. by cualquier está (…) en que, y página
-Hoteles también + servicio población for caso, Más Web hasta los Google of % Inicio 3 son
-2008, MÁS de 30 EN porque España, ” al En 0.00 Copyright 20 tanto, le derechos Música --
-octubre en LG que Versión la contra las España años Registrado: Mensajes: Por 8 PÚBLICA
+Hoteles TAMBIÉN + servicio población for caso, Más Web hasta los Google of % Inicio 3 son
+2008, MÁS de 30 EN porque ESPAÑA, ” al En 0.00 Copyright 20 tanto, le derechos Música --
+octubre en LG que Versión la contra las ESPAÑA AÑOS Registrado: Mensajes: Por 8 PÚBLICA
 cuenta on desde: TRABAJO ¡nuevo! nos Agregar 11 de parte Buscar 50 Esta 2 q Salud país durante
 SERVICIOS iPhone los [...] esta del fueron Nueva Página perfil CD puede ni de Este derechos
 Archivo para Todos página Nuevo San de 4 las Yahoo! así los búsqueda parte, NUEVO mejor hay


### PR DESCRIPTION
When running unicharset_extractor on the Spanish langdata, it warns that capital "Ñ", capital "É" and "«" are absent from the training text (while their counterparts, "ñ", "é" and "»", are present). This makes Tesseract then fail to recognize this characters with --oem 0 (for example, it recognizes "Ñ" as "NN", and "É" as "EI").
I'm a beginner in the subject of Tesseract training and I'm not sure how these training_text files are generated. It seems to me they are more or less a random set of words and short phrases. It occurred to me I could simply make some replacements to cover these missing characters: España -> ESPAÑA, años -> AÑOS, también -> TAMBIÉN, México -> MÉXICO, and also replaced half occurrences of "»" with "«".
If my assumption that this file is mostly random, please consider pulling this commit into master. Thank you
