### PR TITLE
Fix extra intra-word spacing in Chinese and Japanese (GitHub issue #991)

### DIFF
--- a/chi_sim/chi_sim.config
+++ b/chi_sim/chi_sim.config
@@ -1,7 +1,5 @@
-#Fixes https://github.com/tesseract-ocr/tesseract/issues/991
-preserve_interword_spaces 1
-
 tessedit_load_sublangs chi_sim_vert
+
 # Important configurations for CJK mode
 
 # New Segmentation search params

--- a/chi_sim_vert/chi_sim_vert.config
+++ b/chi_sim_vert/chi_sim_vert.config
@@ -1,5 +1,8 @@
 # Important configurations for CJK mode
 
+# Fix https://github.com/tesseract-ocr/tesseract/issues/991
+preserve_interword_spaces 1
+
 # New Segmentation search params
 language_model_ngram_on             1
 segsearch_max_char_wh_ratio         1.3

--- a/chi_tra/chi_tra.config
+++ b/chi_tra/chi_tra.config
@@ -1,8 +1,5 @@
 tessedit_load_sublangs chi_tra_vert
 
-# Fix https://github.com/tesseract-ocr/tesseract/issues/991
-preserve_interword_spaces 1
-
 # Important configurations for CJK mode
 
 # New Segmentation search params

--- a/chi_tra_vert/chi_tra_vert.config
+++ b/chi_tra_vert/chi_tra_vert.config
@@ -1,5 +1,8 @@
 # Important configurations for CJK mode
 
+# Fix https://github.com/tesseract-ocr/tesseract/issues/991
+preserve_interword_spaces 1
+
 # New Segmentation search params
 language_model_ngram_on             1
 segsearch_max_char_wh_ratio         1.3

--- a/jpn/jpn.config
+++ b/jpn/jpn.config
@@ -1,6 +1,3 @@
-#Fixes https://github.com/tesseract-ocr/tesseract/issues/988
-preserve_interword_spaces 1
-
 tessedit_load_sublangs jpn_vert
 # Important configurations for CJK mode
 

--- a/jpn_vert/jpn_vert.config
+++ b/jpn_vert/jpn_vert.config
@@ -1,5 +1,8 @@
 # Important configurations for CJK mode
 
+# Fix https://github.com/tesseract-ocr/tesseract/issues/991
+preserve_interword_spaces 1
+
 # New Segmentation search params
 language_model_ngram_on         1
 segsearch_max_char_wh_ratio     1.3


### PR DESCRIPTION
Add `preserve_interword_spaces 1` to the *_vert.traineddata.

It can be removed now from traineddata which loads those files
as a sublanguage.

Signed-off-by: Stefan Weil <sw@weilnetz.de>